### PR TITLE
BugFix dealing with edge fall off in Select module

### DIFF
--- a/src/libnoiseforjava/module/Select.java
+++ b/src/libnoiseforjava/module/Select.java
@@ -119,7 +119,7 @@ public class Select extends ModuleBase
             alpha = Interp.SCurve3 (
                   (controlValue - lowerCurve) / (upperCurve - lowerCurve));
             return Interp.linearInterp (sourceModules[0].getValue (x, y, z),
-                  sourceModules[2].getValue (x, y, z),
+                  sourceModules[1].getValue (x, y, z),
                   alpha);
          }
          else if (controlValue < (upperBound - edgeFalloff))
@@ -202,7 +202,7 @@ public class Select extends ModuleBase
    {
       // Make sure that the edge falloff curves do not overlap.
       double boundSize = upperBound - lowerBound;
-      edgeFalloff = (edgeFalloff > boundSize / 2)? boundSize / 2: edgeFalloff;
+      this.edgeFalloff = (edgeFalloff > boundSize / 2)? boundSize / 2: edgeFalloff;
    }
 
    /// Returns the control module.


### PR DESCRIPTION
The local variable edgeFallOff was being set instead of the field(Line 205). The getValue method was also using the control module instead of the second module(Line 122).

I submitted this as a pull request to the original repository as well, but yours seems like the most likely one to be updated.

Sorry for that last pull request, I closed it. I didn't like it saying 600 changes, there are only 2.
